### PR TITLE
Csl dynamic titles

### DIFF
--- a/scripts/ColonyMinerals.js
+++ b/scripts/ColonyMinerals.js
@@ -47,18 +47,16 @@ export const colonyTitle = () => {
         return "Colony Minerals"
     } else {
 
-        let html = "<ul>"
+        
 //iterate through our copy of the governor data from our database 
         //then check if the governor's id matches the selected governor 
         for (const governor of foundGovernors) {
             if (governor.id === tempState.selectedGovernor) {
                 const foundColony = colonies.find(colony => colony.id === governor.colonyId)
-                html += `<li>${foundColony.name} Minerals</li>`
+                return `<h2>${foundColony.name} Minerals<h2>`
             }
         }
-        html += "</ul>"
-
-        return html 
+       
     }
 }
 

--- a/scripts/Exomine.js
+++ b/scripts/Exomine.js
@@ -8,7 +8,7 @@ import { colonyTitle } from "./ColonyMinerals.js"
     
 
 
-import { FacilityMinerals, lowerColonyTitle } from "./FacilityMinerals.js"
+import { FacilityMinerals, facilityMineralTitle } from "./FacilityMinerals.js"
 
 
 
@@ -36,7 +36,7 @@ export const Exomine = () => {
     </article>
     <article class="lower">
         <section class="facilityMinerals">
-            <h2 class="facilityMinerals__title">${lowerColonyTitle()}</h2>
+            <h2 class="facilityMinerals__title">${facilityMineralTitle()}</h2>
             <div class="facilityMinerals__list">
                 ${FacilityMinerals()}
             </div>

--- a/scripts/FacilityMinerals.js
+++ b/scripts/FacilityMinerals.js
@@ -39,7 +39,7 @@ export const FacilityMinerals = () => {
 
 //defining export function that dynamically changes the title based on governor selection
 
-export const lowerColonyTitle = () => {
+export const facilityMineralTitle = () => {
     const foundGovernors = getGovernors()
     const tempState = getTransientState()
     const colonies = getColonies()
@@ -48,7 +48,7 @@ export const lowerColonyTitle = () => {
         return "Facility Minerals"
     } else {
 
-        let html = "<ul>"
+        
         //iterate through our copy of the governor data from our database 
         //then check if the governor's id matches the selected governor 
         for (const governor of foundGovernors) {
@@ -56,11 +56,9 @@ export const lowerColonyTitle = () => {
                 //find the colony id that matches the governor's colonyId
                 const foundColony = colonies.find(colony => colony.id === governor.colonyId)
                 //render dynamic title in html 
-                html += `<li>Facility Minerals for ${foundColony.name}</li>`
+                return `<h2>Facility Minerals for ${foundColony.name}</h2>`
             }
         }
-        html += "</ul>"
-
-        return html 
+        
     }
 }


### PR DESCRIPTION
# Description

Added dynamic titles for colony minerals and facility minerals so that they display new html when a governor is selected 

Fixes # (issue)
#29 
## Type of change
took out hardcoded titles in exomine.js and wrote functions to dynamically generate html based on governor selection 
Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?



- [ ] served to browser to ensure that the html was rendering properly when different governors were selected or if no governor was selected 


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
